### PR TITLE
feat(auth): persist authentication using localStorage

### DIFF
--- a/frontend/modules/auth/context/AuthContext.tsx
+++ b/frontend/modules/auth/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 //frontend\modules\auth\context\AuthContext.tsx
 "use client";
 
+import { useEffect } from "react";
 import { createContext, useState } from "react";
 import { AuthContextType, User } from "../types/auth.types";
 
@@ -9,9 +10,7 @@ export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
 
-  // 🔹 Mock login (por ahora)
   const login = async (email: string, password: string) => {
-    // simula llamada async
     await new Promise((res) => setTimeout(res, 500));
 
     const mockUser: User = {
@@ -20,11 +19,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     setUser(mockUser);
+    localStorage.setItem("auth_user", JSON.stringify(mockUser));
   };
 
   const logout = () => {
     setUser(null);
+
+    localStorage.removeItem("auth_user");
   };
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem("auth_user");
+  
+    if (storedUser) {
+      setUser(JSON.parse(storedUser));
+    }
+  }, []);
 
   return (
     <AuthContext.Provider value={{ user, login, logout }}>


### PR DESCRIPTION
## Summary
Adds persistence to authentication state using localStorage, ensuring user sessions are maintained across page reloads.

### Changes

- Store user data in localStorage on login
- Load user from localStorage on app initialization
- Clear stored user data on logout
- Sync localStorage with React state
- Ensure persistence logic runs only on client side

###  Impact

- No backend changes
- Improves user experience by maintaining session
- Eliminates need to re-login on page refresh
- Prepares app for token-based authentication

### Technical Notes

- Uses `localStorage` for client-side persistence
- Hydrates auth state via `useEffect` on mount
- JSON serialization/deserialization for storage
- Requires `"use client"` to avoid SSR issues
- Key used: `auth_user`
- Safe fallback when no stored user exists

### Related Issue

Closes #4 