### PR TITLE
feat(sessions): implement session lifecycle endpoints

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,8 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/platform-express": "^11.0.1",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.15.1",
         "cookie-parser": "^1.4.7",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
@@ -2899,6 +2901,12 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -4376,6 +4384,23 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.22"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -7296,6 +7321,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.41",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
+      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9725,6 +9756,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,8 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/platform-express": "^11.0.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
     "cookie-parser": "^1.4.7",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { SessionsModule } from './sessions/sessions.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { AuthModule } from './auth/auth.module';
       isGlobal: true, 
     }),
     AuthModule,
+    SessionsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,14 +1,26 @@
-//backend\src\main.ts
+// backend/src/main.ts
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ConfigService } from '@nestjs/config';
-import cookieParser from 'cookie-parser'; 
+import { ValidationPipe } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.use(cookieParser()); 
+  // COOKIES
+  app.use(cookieParser());
 
+  // VALIDATION 
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
+  // CORS
   app.enableCors({
     origin: [
       "http://localhost:3000",

--- a/backend/src/sessions/dto/start-session.dto.ts
+++ b/backend/src/sessions/dto/start-session.dto.ts
@@ -1,0 +1,12 @@
+//backend\src\sessions\dto\start-session.dto.ts
+import { IsArray, IsOptional, IsString, ArrayNotEmpty } from 'class-validator';
+
+export class StartSessionDto {
+  @IsString()
+  task: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  allowedSites?: string[];
+}

--- a/backend/src/sessions/dto/stop-session.dto.ts
+++ b/backend/src/sessions/dto/stop-session.dto.ts
@@ -1,0 +1,7 @@
+//backend\src\sessions\dto\stop-session.dto.ts
+import { IsUUID } from 'class-validator';
+
+export class StopSessionDto {
+  @IsUUID()
+  sessionId: string;
+}

--- a/backend/src/sessions/sessions.controller.ts
+++ b/backend/src/sessions/sessions.controller.ts
@@ -1,0 +1,51 @@
+//backend\src\sessions\sessions.controller.ts
+import {
+    Body,
+    Controller,
+    Get,
+    Post,
+    Req,
+    UseGuards,
+  } from '@nestjs/common';
+  
+  import { SessionsService } from './sessions.service';
+  import { StartSessionDto } from './dto/start-session.dto';
+  import { StopSessionDto } from './dto/stop-session.dto';
+  import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+  
+  import { Request } from 'express';
+  
+  type RequestWithUser = Request & {
+    user: {
+      sub: string;
+      email: string;
+    };
+  };
+  
+  @Controller('sessions')
+  @UseGuards(JwtAuthGuard)
+  export class SessionsController {
+    constructor(private readonly sessionsService: SessionsService) {}
+  
+    @Post('start')
+    startSession(
+      @Req() req: RequestWithUser,
+      @Body() dto: StartSessionDto,
+    ) {
+      const userId = req.user.sub;
+  
+      return this.sessionsService.startSession(userId, dto);
+    }
+  
+    @Post('stop')
+    stopSession(@Body() dto: StopSessionDto) {
+      return this.sessionsService.stopSession(dto.sessionId);
+    }
+  
+    @Get()
+    getSessions(@Req() req: RequestWithUser) {
+      const userId = req.user.sub;
+  
+      return this.sessionsService.getSessionsByUser(userId);
+    }
+  }

--- a/backend/src/sessions/sessions.module.ts
+++ b/backend/src/sessions/sessions.module.ts
@@ -1,0 +1,10 @@
+//backend\src\sessions\sessions.module.ts
+import { Module } from '@nestjs/common';
+import { SessionsController } from './sessions.controller';
+import { SessionsService } from './sessions.service';
+
+@Module({
+  controllers: [SessionsController],
+  providers: [SessionsService],
+})
+export class SessionsModule {}

--- a/backend/src/sessions/sessions.service.ts
+++ b/backend/src/sessions/sessions.service.ts
@@ -1,0 +1,60 @@
+//backend\src\sessions\sessions.service.ts
+import {
+    Injectable,
+    NotFoundException,
+    BadRequestException,
+  } from '@nestjs/common';
+  import { Session } from './types/session.type';
+  import { StartSessionDto } from './dto/start-session.dto';
+  import { randomUUID } from 'crypto';
+  
+  @Injectable()
+  export class SessionsService {
+    private sessions: Session[] = [];
+  
+    startSession(userId: string, dto: StartSessionDto): Session {
+      
+      const activeSession = this.sessions.find(
+        (s) => s.userId === userId && s.endTime === null,
+      );
+  
+      if (activeSession) {
+        throw new BadRequestException(
+          'User already has an active session',
+        );
+      }
+  
+      const newSession: Session = {
+        id: randomUUID(),
+        userId,
+        task: dto.task,
+        allowedSites: dto.allowedSites,
+        startTime: new Date(),
+        endTime: null,
+      };
+  
+      this.sessions.push(newSession);
+  
+      return newSession;
+    }
+  
+    stopSession(sessionId: string): Session {
+      const session = this.sessions.find((s) => s.id === sessionId);
+  
+      if (!session) {
+        throw new NotFoundException('Session not found');
+      }
+  
+      if (session.endTime) {
+        throw new BadRequestException('Session already stopped');
+      }
+  
+      session.endTime = new Date();
+  
+      return session;
+    }
+  
+    getSessionsByUser(userId: string): Session[] {
+      return this.sessions.filter((s) => s.userId === userId);
+    }
+  }

--- a/backend/src/sessions/types/session.type.ts
+++ b/backend/src/sessions/types/session.type.ts
@@ -1,0 +1,15 @@
+//backend\src\sessions\types\session.type.ts
+export type Session = {
+    id: string;
+    userId: string;
+    task: string;
+    allowedSites?: string[];
+    startTime: Date;
+    endTime: Date | null;
+  
+    // métricas (futuro)
+    focusTime?: number;
+    idleTime?: number;
+    interruptions?: number;
+    score?: number;
+  };


### PR DESCRIPTION
### Summary

Implements the core session lifecycle by adding endpoints to start, stop, and retrieve focus sessions, establishing the foundation for tracking and analytics.

### Changes

- Create sessions module (controller + service)
- Add Session entity/model
- Implement POST /sessions/start
- Implement POST /sessions/stop
- Implement GET /sessions
- Store startTime and endTime
- Link sessions to authenticated users

### Impact

- Enables core focus tracking functionality
- Required for event tracking and metrics calculation
- Establishes base data structure for analytics

### Technical Notes

- Ensures only one active session per user
- Uses authenticated user context (JWT)
- Prepared for future event linkage (events → sessionId)
- Designed for scalability with future metrics processing

### Related Issue

Closes #16