### PR TITLE
feat(metrics): implement session metrics calculation

### DIFF
--- a/backend/src/sessions/sessions.service.ts
+++ b/backend/src/sessions/sessions.service.ts
@@ -16,7 +16,7 @@ import {
   @Injectable()
   export class SessionsService {
     private sessions: Session[] = [];
-    private events: Event[] = []; 
+    private events: Event[] = [];
   
     // ======================
     // SESSION LIFECYCLE
@@ -60,6 +60,13 @@ import {
   
       session.endTime = new Date();
   
+      const metrics = this.computeMetrics(sessionId);
+  
+      session.focusTime = metrics.focusTime;
+      session.idleTime = metrics.idleTime;
+      session.interruptions = metrics.interruptions;
+      session.score = metrics.score;
+  
       return session;
     }
   
@@ -100,4 +107,67 @@ import {
     getEventsBySession(sessionId: string): Event[] {
       return this.events.filter((e) => e.sessionId === sessionId);
     }
+  
+    // ======================
+    // METRICS
+    // ======================
+  
+    private computeMetrics(sessionId: string) {
+        const events = this.events
+          .filter((e) => e.sessionId === sessionId)
+          .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+      
+        if (events.length === 0) {
+          return {
+            focusTime: 0,
+            idleTime: 0,
+            interruptions: 0,
+            score: 0,
+          };
+        }
+      
+        let focusTime = 0;
+        let idleTime = 0;
+        let interruptions = 0;
+      
+        for (let i = 0; i < events.length - 1; i++) {
+          const current = events[i];
+          const next = events[i + 1];
+      
+          const diff =
+            (next.timestamp.getTime() - current.timestamp.getTime()) / 1000;
+      
+          if (current.type === 'ACTIVE') focusTime += diff;
+          if (current.type === 'IDLE') {
+            idleTime += diff;
+            interruptions++;
+          }
+          if (current.type === 'TAB_CHANGE') interruptions++;
+        }
+      
+        const lastEvent = events[events.length - 1];
+        const session = this.sessions.find((s) => s.id === sessionId);
+      
+        if (session?.endTime && lastEvent) {
+          const diff =
+            (session.endTime.getTime() - lastEvent.timestamp.getTime()) / 1000;
+      
+          if (lastEvent.type === 'ACTIVE') focusTime += diff;
+          if (lastEvent.type === 'IDLE') idleTime += diff;
+        }
+      
+        const totalTime = focusTime + idleTime;
+      
+        const score =
+          totalTime > 0
+            ? Math.round((focusTime / totalTime) * 100)
+            : 0;
+      
+        return {
+          focusTime: Math.round(focusTime / 60),
+          idleTime: Math.round(idleTime / 60),
+          interruptions,
+          score,
+        };
+      }
   }


### PR DESCRIPTION
## Summary

Implements the transformation of raw session events into meaningful metrics, enabling analysis of user focus behavior.

### Changes

- Process session events chronologically
- Calculate focusTime from ACTIVE events
- Calculate idleTime from IDLE events
- Count interruptions from TAB_CHANGE events
- Compute basic focus score
- Attach metrics to session

### Impact

- Enables meaningful analytics from raw tracking data
- Required for dashboards and insights
- Foundation for AI-based feedback and recommendations

### Technical Notes

- Uses time deltas between consecutive events
- Handles edge cases (missing events, session end states)
- Metrics stored at session level for fast access
- Designed for future extensibility (advanced scoring, ML models)

### Related Issue

Closes #18