### PR TITLE
feat(focus): connect focus page to backend sessions

### DIFF
--- a/frontend/app/(app)/focus/page.tsx
+++ b/frontend/app/(app)/focus/page.tsx
@@ -1,7 +1,7 @@
 //frontend\app\(app)\focus\page.tsx
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Brain,
   Globe,
@@ -11,20 +11,88 @@ import {
   Activity,
 } from "lucide-react";
 
+import {
+  startSessionRequest,
+  stopSessionRequest,
+  sendEventRequest,
+} from "@/services/session/session.service";
+
 export default function FocusPage() {
   const [task, setTask] = useState("");
   const [allowedSites, setAllowedSites] = useState("");
   const [cameraEnabled, setCameraEnabled] = useState(false);
+
+  const [sessionId, setSessionId] = useState<string | null>(null);
   const [sessionActive, setSessionActive] = useState(false);
+  const [loading, setLoading] = useState(false);
 
-  const handleStart = () => {
+  // ======================
+  // START SESSION
+  // ======================
+  const handleStart = async () => {
     if (!task) return alert("Add a task before starting");
-    setSessionActive(true);
+
+    try {
+      setLoading(true);
+
+      const res = await startSessionRequest({
+        task,
+        allowedSites: allowedSites
+          ? allowedSites.split(",").map((s) => s.trim())
+          : [],
+      });
+
+      setSessionId(res.id);
+      setSessionActive(true);
+    } catch (err) {
+      console.error(err);
+      alert("Error starting session");
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const handleStop = () => {
-    setSessionActive(false);
+  // ======================
+  // STOP SESSION
+  // ======================
+  const handleStop = async () => {
+    if (!sessionId) return;
+
+    try {
+      setLoading(true);
+
+      const result = await stopSessionRequest(sessionId);
+
+      console.log("Session result:", result);
+
+      // aquí luego mostramos métricas en UI
+      alert(`Score: ${result.score}`);
+
+      setSessionActive(false);
+      setSessionId(null);
+    } catch (err) {
+      console.error(err);
+      alert("Error stopping session");
+    } finally {
+      setLoading(false);
+    }
   };
+
+  // ======================
+  // EVENT LOOP (MVP)
+  // ======================
+  useEffect(() => {
+    if (!sessionActive || !sessionId) return;
+
+    const interval = setInterval(() => {
+      sendEventRequest({
+        sessionId,
+        type: "ACTIVE",
+      });
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [sessionActive, sessionId]);
 
   return (
     <div className="p-8 space-y-8 bg-gray-50 min-h-screen">
@@ -53,14 +121,11 @@ export default function FocusPage() {
             value={task}
             onChange={(e) => setTask(e.target.value)}
             placeholder="What are you working on?"
-            className="
-              border border-gray-200 rounded-lg px-3 py-2.5 text-sm
-              focus:outline-none focus:ring-2 focus:ring-blue-500
-            "
+            className="border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
-        {/* CONTEXT */}
+        {/* CONTEXT (OPCIONAL) */}
         <div className="flex flex-col gap-1.5">
           <label className="text-sm text-gray-500 flex items-center gap-2">
             <Globe size={14} />
@@ -70,11 +135,8 @@ export default function FocusPage() {
           <input
             value={allowedSites}
             onChange={(e) => setAllowedSites(e.target.value)}
-            placeholder="e.g. github.com, docs.google.com"
-            className="
-              border border-gray-200 rounded-lg px-3 py-2.5 text-sm
-              focus:outline-none focus:ring-2 focus:ring-blue-500
-            "
+            placeholder="Optional: limit distractions (future feature)"
+            className="border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
@@ -82,7 +144,6 @@ export default function FocusPage() {
 
       {/* SENSORS */}
       <div className="bg-white rounded-xl p-6 shadow-sm flex items-center justify-between">
-
         <div>
           <p className="text-sm font-medium text-gray-700 flex items-center gap-2">
             <Camera size={16} />
@@ -95,13 +156,10 @@ export default function FocusPage() {
 
         <button
           onClick={() => setCameraEnabled((prev) => !prev)}
-          className={`
-            px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2
-            transition
+          className={`px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition
             ${cameraEnabled
               ? "bg-green-600 text-white"
-              : "bg-gray-200 text-gray-700 hover:bg-gray-300"}
-          `}
+              : "bg-gray-200 text-gray-700 hover:bg-gray-300"}`}
         >
           <Activity size={14} />
           {cameraEnabled ? "Enabled" : "Enable"}
@@ -124,15 +182,11 @@ export default function FocusPage() {
 
       {/* CONTROLS */}
       <div className="flex gap-3">
-
         {!sessionActive ? (
           <button
             onClick={handleStart}
-            className="
-              flex items-center gap-2
-              px-6 py-3 bg-blue-600 text-white rounded-lg
-              hover:bg-blue-700 transition font-medium
-            "
+            disabled={loading}
+            className="flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-medium disabled:opacity-50"
           >
             <PlayCircle size={18} />
             Start Session
@@ -140,17 +194,13 @@ export default function FocusPage() {
         ) : (
           <button
             onClick={handleStop}
-            className="
-              flex items-center gap-2
-              px-6 py-3 bg-red-600 text-white rounded-lg
-              hover:bg-red-700 transition font-medium
-            "
+            disabled={loading}
+            className="flex items-center gap-2 px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition font-medium disabled:opacity-50"
           >
             <StopCircle size={18} />
             Stop Session
           </button>
         )}
-
       </div>
 
     </div>

--- a/frontend/services/session/session.service.ts
+++ b/frontend/services/session/session.service.ts
@@ -1,0 +1,53 @@
+//frontend\services\session.service.ts
+const API_URL = process.env.NEXT_PUBLIC_API_URL!;
+
+// START
+export async function startSessionRequest(data: {
+  task: string;
+  allowedSites?: string[];
+}) {
+  const res = await fetch(`${API_URL}/sessions/start`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) throw new Error("Failed to start session");
+
+  return res.json();
+}
+
+// EVENT
+export async function sendEventRequest(data: {
+  sessionId: string;
+  type: "ACTIVE" | "IDLE" | "TAB_CHANGE";
+  value?: string;
+}) {
+  await fetch(`${API_URL}/sessions/event`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+}
+
+// STOP
+export async function stopSessionRequest(sessionId: string) {
+  const res = await fetch(`${API_URL}/sessions/stop`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ sessionId }),
+  });
+
+  if (!res.ok) throw new Error("Failed to stop session");
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary

Connects the focus page UI with backend session endpoints, enabling users to start, track, and stop real focus sessions.

### Changes

- Call POST /sessions/start on session start
- Store sessionId in frontend state
- Send periodic events to /sessions/event
- Call POST /sessions/stop on session end
- Add error handling for API interactions
- Manage session lifecycle in UI

### Impact

- Enables full end-to-end session tracking
- Connects frontend with backend core system
- Required for real data collection and metrics

### Technical Notes

- Uses centralized state for sessionId management
- Implements periodic event dispatching
- Handles API failures gracefully
- Cleans up intervals and state on session end

### Related Issue

Closes #19